### PR TITLE
Add recommended project-level extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "aaron-bond.better-comments",
+    "coenraads.bracket-pair-colorizer-2",
+    "streetsidesoftware.code-spell-checker",
+    "dsznajder.es7-react-js-snippets",
+    "dbaeumer.vscode-eslint",
+    "oderwat.indent-rainbow",
+    "tyriar.sort-lines",
+    "tabnine.tabnine-vscode",
+    "esbenp.prettier-vscode"
+  ]
+}


### PR DESCRIPTION
Add recommended project-level extensions for VS Code so that contributors can have a shared list of extensions to use and pull from.